### PR TITLE
Update Corefile

### DIFF
--- a/docker/vol/coredns/config/Corefile
+++ b/docker/vol/coredns/config/Corefile
@@ -32,7 +32,7 @@ tls://.:853 {
     tls fchain.pem key.pem
     
     # We use the $PIHOLE_IP environment variable to point coreDNS to the pihole
-    proxy . dns://{$PIHOLE_IP}
+    forward . dns://{$PIHOLE_IP}
 }
 
 # Listen for plain old DNS queries


### PR DESCRIPTION
Correct the `Corefile` use of `proxy` with `forward`. Proxy directive was deprecated here:

https://github.com/coredns/coredns/issues/1443